### PR TITLE
fix certificate null pointer exception when conjur plugin is used in combination of JCASC plugin

### DIFF
--- a/src/main/java/org/conjur/jenkins/api/ConjurAPIUtils.java
+++ b/src/main/java/org/conjur/jenkins/api/ConjurAPIUtils.java
@@ -46,6 +46,7 @@ public class ConjurAPIUtils {
 		CertificateCredentials certificate = null;
 
 		if (channel == null) {
+			if (configuration.getCertificateCredentialID() == null ) { return null;}
 			certificate = CredentialsMatchers.firstOrNull(
 					CredentialsProvider.lookupCredentials(CertificateCredentials.class, Jenkins.get(), ACL.SYSTEM,
 							Collections.<DomainRequirement>emptyList()),

--- a/src/main/java/org/conjur/jenkins/api/ConjurAPIUtils.java
+++ b/src/main/java/org/conjur/jenkins/api/ConjurAPIUtils.java
@@ -44,7 +44,6 @@ public class ConjurAPIUtils {
 		Channel channel = Channel.current();
 
 		CertificateCredentials certificate = null;
-
 		if (channel == null) {
 			if (configuration.getCertificateCredentialID() == null ) { return null;}
 			certificate = CredentialsMatchers.firstOrNull(


### PR DESCRIPTION
This fix allow conjur plugin to work correctly with the JCASC plugin avoiding a null point exeception when the conjur certificate is configured in the jenkins CACERTS instead of .p12 uploaded as a jenkins certificate.