### PR TITLE
Docs as code on plugins.jenkins.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to the conjur credentials plugin
+
+## Building from Source
+
+To build the plugin from source, Maven is required. Build it like this:
+
+```bash
+git clone https://github.com/jenkinsci/conjur-credentials-plugin
+cd conjur-credentials-plugin
+mvn clean install
+```
+
+## Installing from Binaries
+
+As another option, you can use the latest .hpi found under the binaries folder.
+
+### Install in Jenkins
+
+When you have the .hpi file, log into Jenkins as an administrator.
+Then go to **Jenkins** -> **Manage Jenkins** -> **Manage Plugins** -> **Advanced**.
+In the **Upload Plugin** section, browse for the .hpi and upload it to Jenkins:
+
+![Upload Plugin](docs/images/UploadPlugin-Jenkins.png)
+
+After installing the plugin, restart Jenkins:
+
+![Install Plugin](docs/images/Plugin-Installing.png)

--- a/README.md
+++ b/README.md
@@ -4,22 +4,6 @@ This Conjur plugin securely provides credentials that are stored in Conjur to Je
 
 ## Installation
 
-### From Source
-
-To build the plugin from source, Maven is required. Build it like this:
-
-```bash
-git clone {repo}
-cd conjur-credentials-plugin
-mvn clean install
-```
-
-### From Binaries
-
-As another option, you can use the latest .hpi found under the binaries folder.
-
-### Install in Jenkins
-
 When you have the .hpi file, log into Jenkins as an administrator. Then go to **Jenkins** -> **Manage Jenkins** -> **Manage Plugins** -> **Advanced**.
 In the **Upload Plugin** section, browse for the .hpi and upload it to Jenkins:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The secrets that you want to obtain from Conjur must be defined explicitly. Use 
 To reference Conjur secrets in a Jenkins script, use `withCredentials` and the symbol `conjurSecretCredential`.  
 Here is an example showing how to fetch the secret from a Jenkins job pipeline definition.
 
-```yml
+```groovy
 node {
    stage('Work') {
       withCredentials([conjurSecretCredential(credentialsId: 'DB_PASSWORD', 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ node {
    stage('Work') {
       withCredentials([conjurSecretCredential(credentialsId: 'DB_PASSWORD', 
                                               variable: 'SECRET')]) {
-         echo "Hello World $SECRET"
+         echo 'Hello World $SECRET'
       }
    }
    stage('Results') {
-      echo "Finished!"
+      echo 'Finished!'
    }
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <name>Conjur Secrets Plugin</name>
     <description>Plugin to retrieve secrets from CyberArk/Conjur</description>
     <version>1.0.4</version>
-    <url>https://www.conjur.org</url>
+    <url>https://github.com/jenkinsci/conjur-credentials-plugin</url>
     
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
     <licenses>


### PR DESCRIPTION
# Use README.md as doc source for [plugins.jenkins.io](https://plugins.jenkins.io/conjur-credentials/)

### What does this PR do?
- _What's changed? Why were these changes made?_
  - Fix the [plugin.jenkins.io docs](https://plugins.jenkins.io/conjur-credentials/) with the next plugin release
  - Move contributing info to a CONTRIBUTING file
  - Use README as docs at plugins.jenkins.io
- _How should the reviewer approach this PR, especially if manual tests are required?_ 
  No manual tests required, documentation change
- _Are there relevant screenshots you can add to the PR description?_  
  Not applicable

### What ticket does this PR close?
Resolves [issue #41](https://github.com/cyberark/conjur-credentials-plugin/issues/41)

### Checklists

#### Change log
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
