### PR TITLE
Fix lock on FINE logs

### DIFF
--- a/src/main/java/org/conjur/jenkins/credentials/ConjurCredentialProvider.java
+++ b/src/main/java/org/conjur/jenkins/credentials/ConjurCredentialProvider.java
@@ -75,8 +75,8 @@ public class ConjurCredentialProvider extends CredentialsProvider {
                                                                         ModelObject context,
                                                                         Authentication authentication) {
 
-        LOGGER.log(Level.FINE, "Type: " + type.getName() + 
-            " authentication: " + authentication + " context: " + context.getDisplayName());        
+        LOGGER.log(Level.FINE, () -> "Type: " + type.getName() +
+            " authentication: " + authentication + " context: " + context.toString());
 
         if (!type.isInstance(CertificateCredentials.class) && (
              (type.isInstance(ConjurSecretCredentials.class) || type == ConjurSecretUsernameCredentials.class) ||


### PR DESCRIPTION
We have seen a production issue with a lock on this log even if FINE level is not enabled.
- Adding closure to have the log computed only if FINE level is enabled
- removing the call to displayName and use the defaut toString() instead

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation