### PR TITLE
Jenkins Plugin Fix to Support Folder Level Credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-
+## [1.0.14] - 2022-12-15
+- Support access of Folder level crdentials to child folders & jobs.
+-
 ## [1.0.13] - 2022-11-23
 - Security updates in pom.xml & support to Java 11. The following depedency updates are made:
 - org.jenkins-ci.plugins is updated from 4.17 to 4.48

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </properties>
     <name>Conjur Secrets Plugin</name>
     <description>Plugin to retrieve secrets from CyberArk/Conjur</description>
-    <version>1.0.13-SNAPSHOT</version>
+    <version>1.0.14-SNAPSHOT</version>
     <url>https://github.com/jenkinsci/conjur-credentials-plugin</url>
     
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </properties>
     <name>Conjur Secrets Plugin</name>
     <description>Plugin to retrieve secrets from CyberArk/Conjur</description>
-    <version>1.0.14-SNAPSHOT</version>
+    <version>1.0.13-SNAPSHOT</version>
     <url>https://github.com/jenkinsci/conjur-credentials-plugin</url>
     
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->

--- a/src/main/java/org/conjur/jenkins/api/ConjurAPI.java
+++ b/src/main/java/org/conjur/jenkins/api/ConjurAPI.java
@@ -81,9 +81,11 @@ public class ConjurAPI {
 				availableCredentials.addAll(CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class,
 				((Run) context).getParent(), ACL.SYSTEM, Collections.<DomainRequirement>emptyList()));
 			} else {
+				if((context instanceof AbstractItem)) {
 				availableCredentials.addAll(CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class,
 				(AbstractItem) context, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()));
-			}
+			      }
+		    }
 		}
 
 		ConjurAuthnInfo conjurAuthn = getConjurAuthnInfo(configuration, availableCredentials, context);
@@ -251,8 +253,8 @@ public class ConjurAPI {
 
 	@SuppressWarnings("unchecked")
 	private static ConjurConfiguration inheritedConjurConfiguration(Item job) {
-		for (ItemGroup<? extends Item> g = job
-				.getParent(); g instanceof AbstractFolder; g = ((AbstractFolder<? extends Item>) g).getParent()) {
+		for (ItemGroup<? extends Item> g = job !=null?
+				job.getParent():null; g instanceof AbstractFolder; g = ((AbstractFolder<? extends Item>) g).getParent()) {
 			FolderConjurConfiguration fconf = ((AbstractFolder<?>) g).getProperties()
 					.get(FolderConjurConfiguration.class);
 			if (!(fconf == null || fconf.getInheritFromParent())) {

--- a/src/main/java/org/conjur/jenkins/conjursecrets/ConjurSecretCredentials.java
+++ b/src/main/java/org/conjur/jenkins/conjursecrets/ConjurSecretCredentials.java
@@ -4,15 +4,14 @@ import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.conjur.jenkins.configuration.ConjurConfiguration;
+
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsNameProvider;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.NameWith;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-
-import org.conjur.jenkins.configuration.ConjurConfiguration;
-import org.conjur.jenkins.exceptions.InvalidConjurSecretException;
 
 import hudson.model.AbstractItem;
 import hudson.model.Item;
@@ -39,6 +38,8 @@ public interface ConjurSecretCredentials extends StandardCredentials {
 
 	}
 
+	public static final Logger LOGGER = Logger.getLogger(ConjurSecretCredentials.class.getName());
+
 	String getDisplayName();
 
 	String getNameTag();
@@ -57,49 +58,145 @@ public interface ConjurSecretCredentials extends StandardCredentials {
 
 	void setContext(ModelObject context);
 
-	static ConjurSecretCredentials credentialFromContextIfNeeded(ConjurSecretCredentials credential, String credentialID, ModelObject context) {
+	static ConjurSecretCredentials credentialFromContextIfNeeded(ConjurSecretCredentials credential,
+			String credentialID, ModelObject context) {
 		if (credential == null && context != null) {
 			getLogger().log(Level.FINE, "NOT FOUND at Jenkins Instance Level!");
 			Item folder = null;
+
 			if (context instanceof Run) {
-				folder = Jenkins.get().getItemByFullName(((Run<?, ?>)context).getParent().getParent().getFullName());
+				LOGGER.log(Level.FINE, "Inside Conjur Credentials>>" + context.getDisplayName());
+				folder = Jenkins.get().getItemByFullName(((Run<?, ?>) context).getParent().getParent().getFullName());
 			} else {
-				folder = Jenkins.get().getItemByFullName(((AbstractItem)((AbstractItem)context).getParent()).getParent().getFullName());
+
+				LOGGER.log(Level.FINE, "Inside not Conjur Credentials>>" + context.getDisplayName());
+				folder = Jenkins.get().getItemByFullName((((AbstractItem)context)).getDisplayName());
+
+				// LOGGER.log(Level.FINE, "Inside not conjur credentials" + (((AbstractItem)
+				// context)).getFullName());
+				// folder = Jenkins.get().getItemByFullName(
+				// ((AbstractItem) ((AbstractItem)
+				// context).getParent()).getParent().getFullName());
+				// LOGGER.log(Level.FINE, "Inside not conjur credentials" + folder);
+
+				/*
+				 * if (folder == null) { LOGGER.log(Level.FINE, "Folder value is null"); folder
+				 * = Jenkins.get() .getItemByFullName(((AbstractItem) ((AbstractItem)
+				 * context).getParent()).getFullName());
+				 * 
+				 * } else { folder = Jenkins.get().getItemByFullName( ((AbstractItem)
+				 * ((AbstractItem) context).getParent()).getParent().getFullName());
+				 * LOGGER.log(Level.FINE, "Inside not conjur credentials parent folder" +
+				 * folder); }
+				 */
+
 			}
-			return CredentialsMatchers
+
+			//folder = (Item) ((Item) context).getParent();
+			LOGGER.log(Level.FINE, "Inside not conjur credentials final folder" + folder);
+			credential = CredentialsMatchers
 					.firstOrNull(
 							CredentialsProvider.lookupCredentials(ConjurSecretCredentials.class, folder, ACL.SYSTEM,
 									Collections.<DomainRequirement>emptyList()),
 							CredentialsMatchers.withId(credentialID));
+			LOGGER.log(Level.FINE, "Returning the Credentials" + credential);
+			LOGGER.log(Level.FINE, "printing value");
+
+			/*
+			 * return CredentialsMatchers .firstOrNull(
+			 * CredentialsProvider.lookupCredentials(ConjurSecretCredentials.class, folder,
+			 * ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
+			 * CredentialsMatchers.withId(credentialID));
+			 */
+			return credential;
 		}
+		LOGGER.log(Level.FINE, "Returning the Credentials" + credential);
 		return credential;
 	}
 
 	static ConjurSecretCredentials credentialWithID(String credentialID, ModelObject context) {
 
-		getLogger().log(Level.FINE, "* CredentialID: {0}", credentialID);
+		//getLogger().log(Level.FINE, "* CredentialID: {0}", credentialID);
+		if (context != null) {
+			//getLogger().log(Level.FINE, "* Context Id: {0}", context.getDisplayName());
+			LOGGER.log(Level.FINE, "* Context Id not null>>>:" + context.getDisplayName());
+
+		}
 
 		ConjurSecretCredentials credential = null;
 
-		credential = CredentialsMatchers
-				.firstOrNull(
-						CredentialsProvider.lookupCredentials(ConjurSecretCredentials.class, Jenkins.get(),
-								ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
-						CredentialsMatchers.withId(credentialID));
+		LOGGER.log(Level.FINE, "* Context Id >>>:" + Jenkins.get());
 
-		credential = credentialFromContextIfNeeded(credential, credentialID, context);
+		credential = CredentialsMatchers.firstOrNull(
+				CredentialsProvider.lookupCredentials(ConjurSecretCredentials.class, Jenkins.get(), ACL.SYSTEM,
+						Collections.<DomainRequirement>emptyList()),
+				CredentialsMatchers.withId(credentialID));
 
+		//credential = credentialFromContextIfNeeded(credential, credentialID, context);
+
+		/*
+		 * if (credential == null) {
+		 * 
+		 * String contextLevel =
+		 * String.format("Unable to find credential at %s",context.getDisplayName()); //
+		 * (context != null? context.getDisplayName() : "Global Instance Level")); throw
+		 * new InvalidConjurSecretException(contextLevel); }
+		 */
 
 		if (credential == null) {
-			String contextLevel = String.format("Unable to find credential at %s", 
-												(context != null? context.getDisplayName() : "Global Instance Level"));
-			throw new InvalidConjurSecretException(contextLevel);
+			if (context != null) {
+				LOGGER.log(Level.FINE, "Get all jobs" + context.toString());
+				// String allJobs = toCheck.getAllJobs().toString();
+
+				String[] spiltJob = context.toString().split("/");
+				Item childFolder = null;
+				Item parentFolder = null;
+
+				ConjurSecretCredentials conjurSecretCredential = null;
+
+				if (context instanceof Run) {
+					LOGGER.log(Level.FINE, "Inside Conjur Credentials>>" + context.getDisplayName());
+					childFolder = Jenkins.get().getItemByFullName(((Run<?, ?>) context).getParent().getParent().getFullName());
+				} else {
+
+					LOGGER.log(Level.FINE, "Inside not Conjur Credentials>>" + context.getDisplayName());
+
+					childFolder = Jenkins.get().getItemByFullName(((AbstractItem)((AbstractItem)context).getParent()).getFullName());
+					//Jenkins.get().getItemByFullName((((AbstractItem) context).getParent()).getFullName());
+
+				}
+
+				 //childFolder = Jenkins.get().getItemByFullName(((Job<?, ?>)context).getParent().getFullName());
+				parentFolder =  childFolder;
+				LOGGER.log(Level.FINE, "Child Folder" + childFolder + ">>>>>>" + spiltJob.length);
+
+				for (int i = 0; i < spiltJob.length; i++) {
+
+					LOGGER.log(Level.FINE, "From Binding Credential to Jenkins",parentFolder + "Level" + i);
+
+					conjurSecretCredential = credentialFromContextIfNeeded(credential, credentialID, parentFolder);
+
+					LOGGER.log(Level.FINE, "From Binding Credential" + conjurSecretCredential);
+					credential = conjurSecretCredential;
+					if (conjurSecretCredential == null) {
+						LOGGER.log(Level.FINE,"Inside Credentials not null");
+						// parentFolder = (Item) ((Item) parentFolder).getParent();
+						parentFolder = Jenkins.get()
+								.getItemByFullName((((AbstractItem) parentFolder).getParent()).getFullName());
+
+						LOGGER.log(Level.FINE, "Back to the for loop tocheck for the parent level");
+					}
+
+				}
+
+			}
 		}
 
 		return credential;
 	}
 
-	static void setConjurConfigurationForCredentialWithID(String credentialID, ConjurConfiguration conjurConfiguration, ModelObject context) {
+	static void setConjurConfigurationForCredentialWithID(String credentialID, ConjurConfiguration conjurConfiguration,
+			ModelObject context) {
 
 		ConjurSecretCredentials credential = credentialWithID(credentialID, context);
 
@@ -107,17 +204,17 @@ public interface ConjurSecretCredentials extends StandardCredentials {
 			credential.setConjurConfiguration(conjurConfiguration);
 
 	}
-	
-	static Secret getSecretFromCredentialIDWithConfigAndContext(String credentialID, 
-																ConjurConfiguration conjurConfiguration,
-																ModelObject context,
-																ModelObject storeContext) {
 
-		ModelObject effectiveContext = context != null? context : storeContext;
+	static Secret getSecretFromCredentialIDWithConfigAndContext(String credentialID,
+			ConjurConfiguration conjurConfiguration, ModelObject context, ModelObject storeContext) {
 
-		getLogger().log(Level.FINE, "Getting Secret with CredentialID: {0}  context: " + context + " storeContext: " + storeContext, credentialID);
+		ModelObject effectiveContext = context != null ? context : storeContext;
+
+		getLogger().log(Level.FINE,
+				"Getting Secret with CredentialID: {0}  context: " + context + " storeContext: " + storeContext,
+				credentialID);
 		ConjurSecretCredentials credential = credentialWithID(credentialID, effectiveContext);
-		
+
 		return credential.secretWithConjurConfigAndContext(conjurConfiguration, effectiveContext);
 	}
 

--- a/src/main/java/org/conjur/jenkins/conjursecrets/ConjurSecretCredentialsBinding.java
+++ b/src/main/java/org/conjur/jenkins/conjursecrets/ConjurSecretCredentialsBinding.java
@@ -6,18 +6,27 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import javax.annotation.Nonnull;
+
 import org.conjur.jenkins.credentials.ConjurCredentialStore;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
 import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
+import org.jenkinsci.plugins.credentialsbinding.impl.CredentialNotFoundException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
 
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.model.Descriptor;
+import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import jenkins.model.Jenkins;
 
 public class ConjurSecretCredentialsBinding extends MultiBinding<ConjurSecretCredentials> {
 
@@ -45,24 +54,128 @@ public class ConjurSecretCredentialsBinding extends MultiBinding<ConjurSecretCre
 
 	private String variable;
 
+	private String credentialsId;
+
+	// private ModelObject context;
+
+	private boolean isParent;
+
+	public boolean isParent() {
+		return isParent;
+	}
+
+	public void setParent(boolean isParent) {
+		this.isParent = isParent;
+	}
+
 	@DataBoundConstructor
 	public ConjurSecretCredentialsBinding(String credentialsId) {
 		super(credentialsId);
+		this.credentialsId = credentialsId;
 	}
 
-	@Override
+	// @Override
 	public MultiEnvironment bind(Run<?, ?> build, FilePath workSpace, Launcher launcher, TaskListener listener)
 			throws IOException, InterruptedException {
 		LOGGER.log(Level.FINE, "**** binding **** : " + build);
-		ConjurCredentialStore store = ConjurCredentialStore.getAllStores().get(String.valueOf(build.getParent().hashCode()));
+		ConjurCredentialStore store = ConjurCredentialStore.getAllStores()
+				.get(String.valueOf(build.getParent().hashCode()));
+
 		if (store != null) {
+			LOGGER.log(Level.FINE, "Store details" + store);
 			store.getProvider().getStore(build);
 		}
-		ConjurSecretCredentials conjurSecretCredential = getCredentials(build);
-		conjurSecretCredential.setContext(build);
+
+		// ConjurSecretCredentials conjurSecretCredential = getCredentials(build);
+		ConjurSecretCredentials conjurSecretCredential = getCredentialsFor(build);
+		// LOGGER.log(Level.FINE, "Context Setin binding class" +
+		// conjurSecretCredential.getDisplayName());
+
+		LOGGER.log(Level.FINE, "Get Parent flage status", isParent);
+		if (!isParent) {
+			LOGGER.log(Level.FINE, "Context Set");
+			conjurSecretCredential.setContext(build);
+
+		} else {
+			LOGGER.log(Level.FINE, "Context Set not for parent" + conjurSecretCredential.getDescription());
+			if (conjurSecretCredential != null) {
+				Item item = Jenkins.get().getItemByFullName(conjurSecretCredential.getDescription());// build.getParent();
+				if (item != null) {
+					conjurSecretCredential.setContext(item);
+
+					LOGGER.log(Level.FINE, "Context Set not for parent" + item.getDisplayName());
+				}
+			}
+
+			/*
+			 * Item item = build.getParent();
+			 * 
+			 * if(item !=null) { String parentName =
+			 * ((AbstractItem)(build.getParent()).getParent()).getParent().getDisplayName();
+			 * LOGGER.log(Level.FINE, "Context Set not for parent 1"+parentName);
+			 * if(!parentName.isEmpty() && !parentName.equalsIgnoreCase("Jenkins")) {
+			 * LOGGER.log(Level.FINE,
+			 * "Context Set not for parent 2"+build.getParent().getDisplayName());
+			 * 
+			 * conjurSecretCredential.setContext(((AbstractItem)(build.getParent()).
+			 * getParent()).getParent());
+			 * 
+			 * 
+			 * 
+			 * } else { LOGGER.log(Level.FINE,
+			 * "Context Set not for parent 3"+build.getParent().getParent().getDisplayName()
+			 * ); conjurSecretCredential.setContext(build.getParent().getParent()); } }
+			 */
+
+		}
 
 		return new MultiEnvironment(
 				Collections.singletonMap(variable, conjurSecretCredential.getSecret().getPlainText()));
+	}
+
+	private final @Nonnull <C> C getCredentialsFor(@Nonnull Run<?, ?> build) throws IOException {
+
+		IdCredentials cred = CredentialsProvider.findCredentialById(credentialsId, IdCredentials.class, build);
+		LOGGER.log(Level.FINE, "Calling getCredential For1" + build.getFullDisplayName());
+		String newCredentialId = "";
+
+		if (cred == null) {
+
+			setParent(true);
+
+			Item item = (Item) build.getParent(); // Item item =(Item) build;
+
+			if (item != null) {
+				LOGGER.log(Level.FINE, "Item Name" + item.getParent().getDisplayName());
+				newCredentialId = credentialsId.replaceAll("([${}])", "");
+				LOGGER.log(Level.FINE, "CredentialId after removing ${}" + newCredentialId);
+
+				ConjurSecretCredentials conjurSecretCredential = null;
+
+				// conjurSecretCredential =
+				// ConjurSecretCredentials.credentialWithID(newCredentialId, item);
+				conjurSecretCredential = ConjurSecretCredentials.credentialWithID(newCredentialId, build);
+				LOGGER.log(Level.FINE, "From Binding Credential" + conjurSecretCredential.getDisplayName());
+
+				cred = conjurSecretCredential;
+
+				// CredentialsProvider.findCredentialById(credentialsId,
+				// IdCredentials.class,build);
+				// throw new CredentialNotFoundException("Could not find credentials entry with
+				// // ID '" + credentialsId + "'");
+			}
+		}
+
+		if (type().isInstance(cred)) {
+			CredentialsProvider.track(build, cred);
+			return (C) type().cast(cred);
+		}
+
+		Descriptor<?> expected = Jenkins.getActiveInstance().getDescriptor(type());
+		throw new CredentialNotFoundException(
+				"Credentials '" + credentialsId + "' is of type '" + cred.getDescriptor().getDisplayName() + "' where '"
+						+ (expected != null ? expected.getDisplayName() : type().getName()) + "' was expected");
+
 	}
 
 	public String getVariable() {

--- a/src/main/java/org/conjur/jenkins/conjursecrets/ConjurSecretCredentialsImpl.java
+++ b/src/main/java/org/conjur/jenkins/conjursecrets/ConjurSecretCredentialsImpl.java
@@ -76,7 +76,7 @@ public class ConjurSecretCredentialsImpl extends BaseStandardCredentials impleme
 			// Get Http Client
 			OkHttpClient client = ConjurAPIUtils.getHttpClient(this.conjurConfiguration);
 			// Authenticate to Conjur
-			String authToken = ConjurAPI.getAuthorizationToken(client, this.conjurConfiguration, context);
+			String authToken = ConjurAPI.getAuthorizationToken(client, this.conjurConfiguration, storeContext);
 			// Retrieve secret from Conjur
 			String secretString = ConjurAPI.getSecret(client, this.conjurConfiguration, authToken, this.variablePath);
 			result = secretString;
@@ -105,7 +105,7 @@ public class ConjurSecretCredentialsImpl extends BaseStandardCredentials impleme
 
 	public void setStoreContext(ModelObject storeContext) {
 		LOGGER.log(Level.FINEST, "Setting store context");
-		this.context = storeContext;
+		this.storeContext = storeContext;
 		setConjurConfiguration(ConjurAPI.getConfigurationFromContext(context, storeContext));
 	}
 


### PR DESCRIPTION
### What does this PR do?
Customer reported that child jobs under parent folder cannot access it's credentials. Code changes are made to support access of parent level conjur credentials to it's child folders or jobs.

### What ticket does this PR close?
Resolves access of folder level credentials to child jobs.

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation