### PR TITLE
Continuous Deployment Preparation

### DIFF
--- a/.github/workflow-support/settings.xml
+++ b/.github/workflow-support/settings.xml
@@ -1,0 +1,16 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!-- https://stackoverflow.com/a/31251518/12916 -->
+    <servers>
+        <server>
+            <id>maven.jenkins-ci.org</id>
+            <configuration>
+                <httpHeaders>
+                    <property>
+                        <name>Authorization</name>
+                        <value>Bearer ${env.MAVEN_TOKEN}</value>
+                    </property>
+                </httpHeaders>
+            </configuration>
+        </server>
+    </servers>
+</settings>

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+
+# This workflow uses code from the official plugin publication process, but reduces
+# it to only the steps necessary to publish to artifactory, as the github
+# release will be created by an internal process.
+
+name: Publish Plugin
+on:
+  check_suite:
+    types: [completed]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.verify-ci-status.outputs.result == 'success' }}
+    steps:
+      - name: Verify CI status
+        uses: jenkins-infra/verify-ci-status-action@v1.2.2
+        id: verify-ci-status
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          output_result: true
+
+  publish-plugin:
+    run-on: ubuntu-latest
+    needs: [validate]
+    if: needs.validate.outputs.should_publish == 'true'
+    steps:
+      - name: Check out
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - run: |
+          export MAVEN_OPTS=-Djansi.force=true
+          mvn -B -V -e -s .github/workflow-assets/settings.xml -ntp -Dstyle.color=always -Dset.changelist -DaltDeploymentRepository=maven.jenkins-ci.org::default::https://repo.jenkins-ci.org/releases/ -Pquick-build clean deploy
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}


### PR DESCRIPTION
This PR prepares this plugin for continuous deployment by adding a github workflow for pushing artifacts to artifactory.

This is slightly different from the usual process, as the workflow does not create github releases. That will be handled by an internal Jenkins pipeline.
Implemented Changes

The added workflow is based on https://github.com/jenkins-infra/github-reusable-workflows/blob/main/.github/workflows/maven-cd.yml

### Testing done
No testing so far, its my understanding that CD permissions are required to gain access to the required secrets. But CD access isn't granted until a PR for CD prep has been created, hence this PR.


### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
