### PR TITLE
[JENKINS-75258] Allow system configuration to be saved with plugin enabled

### DIFF
--- a/src/main/resources/org/conjur/jenkins/configuration/GlobalConjurConfiguration/config.jelly
+++ b/src/main/resources/org/conjur/jenkins/configuration/GlobalConjurConfiguration/config.jelly
@@ -157,7 +157,9 @@
       // Call the function initially to set the initial state based on checkbox
       getIdentityFormatToken();
         document.getElementById('jwtAudience').addEventListener('change', disableJwtAudienceInput);
-        document.addEventListener("input", disableSubmitButton);
+        // https://issues.jenkins.io/browse/JENKINS-75258 - Cannot save system configuration if Conjur Credentials plugin is active
+        // TODO: Restore this call when JENKINS-75258 is fixed
+        // document.addEventListener("input", disableSubmitButton);
 
         function disableJwtAudienceInput(){
             var inputEnableIdentityCheckedToken = document.getElementById('enableIdentityFormatFieldsFromToken');

--- a/src/main/resources/org/conjur/jenkins/configuration/GlobalConjurConfiguration/config.jelly
+++ b/src/main/resources/org/conjur/jenkins/configuration/GlobalConjurConfiguration/config.jelly
@@ -196,7 +196,9 @@
                  submitBtn.disabled = false;
              }
          }
-         disableSubmitButton();
+         // https://issues.jenkins.io/browse/JENKINS-75258 - Cannot save system configuration if Conjur Credentials plugin is active
+         // TODO: Restore this call when JENKINS-75258 is fixed
+         // disableSubmitButton();
          disableJwtAudienceInput();
          function selectedFieldSeparator(SelectedSeparatorValue){
              var onChangeWarningSeparatorMsg = document.getElementById("dviWarningSeperator");


### PR DESCRIPTION
## [JENKINS-75258](https://issues.jenkins.io/browse/JENKINS-75258) Allow system configuration to be saved with plugin enabled

[JENKINS-75258](https://issues.jenkins.io/browse/JENKINS-75258) reports that the system configuration cannot be saved from "Manage Jenkins" -> "System" when the Conjur Credentials plugin is installed and enabled.  If the plugin is disabled, the system configuration can be saved.  If the plugin is not installed, the system configuration can be saved.

It appears that the disableSubmitButton JavaScript function is trying to prevent the administrator from saving an incomplete or imperfect configuration.  Administrators generally do not like configuration forms that forbid saving an incomplete configuration.  They expect to save part of the configuration and be able to return to complete the configuration later.

The JavaScript debugging tools report an exception attempting to assign the value true to a field `disabled` of a null object `applyBtn`. That is in the file src/main/resources/org/conjur/jenkins/configuration/GlobalConjurConfiguration/config.jelly

This commit removes the disableSubmitButton() call without removing the implementation of the disableSubmitButton() method.  If the fundamental issue can be fixed, then the call could be enabled again.

### Testing done

Confirmed with interactive testing of Jenkins 2.462.3 that without this fix, I cannot save the system configuration and with this fix, system configuration can be saved.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
